### PR TITLE
Allow setting timeouts when connecting to Plotly.

### DIFF
--- a/src/main/scala/co/theasi/plotly/writer/Api.scala
+++ b/src/main/scala/co/theasi/plotly/writer/Api.scala
@@ -10,6 +10,9 @@ object Api {
   def get(endPoint: String)(implicit server: Server): HttpRequest = {
     val request = Http(server.url + endPoint.stripPrefix("/"))
       .auth(server.credentials.username, server.credentials.key)
+      .timeout(
+        connTimeoutMs=server.connTimeoutMs,
+        readTimeoutMs=server.readTimeoutMs)
       .headers(Seq(
         "Plotly-Client-Platform" -> "scala",
         "Accept" -> "application/json"

--- a/src/main/scala/co/theasi/plotly/writer/Server.scala
+++ b/src/main/scala/co/theasi/plotly/writer/Server.scala
@@ -8,4 +8,6 @@ case object ServerWithDefaultCredentials extends Server {
 trait Server {
   def credentials: Credentials
   def url: String
+  def connTimeoutMs: Int = 2000
+  def readTimeoutMs: Int = 10000
 }

--- a/src/test/scala/co/theasi/plotly/writer/WriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/WriterSpec.scala
@@ -13,6 +13,7 @@ class WriterSpec extends FlatSpec with Matchers {
   implicit val testServer = new Server {
     override val credentials = Credentials("PlotlyImageTest", "786r5mecv0")
     override val url = "https://api.plot.ly/v2/"
+    override val readTimeoutMs = 20000
   }
   val testX1 = Vector(1.0, 2.0, 3.0)
   val testX2 = Vector(1, 2, 3)


### PR DESCRIPTION
Either Plotly or my network connection was particularly slow this
morning, so the tests were failing because the graph requests were
taking too long to come back from Plotly.

This commit gives the ability to configure timeouts when defining the
server, and sets a huge timeout (20s) for the tests.