### PR TITLE
Surface plots with custom x, y values and options

### DIFF
--- a/src/main/scala/co/theasi/plotly/AxisOptions.scala
+++ b/src/main/scala/co/theasi/plotly/AxisOptions.scala
@@ -12,7 +12,8 @@ case class AxisOptions(
   tickFont: Font,
   autoTick: Option[Boolean],
   tickSpacing: Option[Double],
-  tickColor: Option[Color]
+  tickColor: Option[Color],
+  tickLabels: Option[Boolean]
 ) {
   def title(newTitle: String): AxisOptions = copy(title = Some(newTitle))
 
@@ -64,6 +65,9 @@ case class AxisOptions(
     tickColor(Color.rgba(r, g, b, a))
   def tickColor(r: Int, g: Int, b: Int): AxisOptions =
     tickColor(Color.rgb(r, g, b))
+
+  def withTickLabels: AxisOptions = copy(tickLabels = Some(true))
+  def noTickLabels: AxisOptions = copy(tickLabels = Some(false))
 }
 
 object AxisOptions {
@@ -79,6 +83,7 @@ object AxisOptions {
     tickFont = Font(),
     autoTick = None,
     tickSpacing = None,
-    tickColor = None
+    tickColor = None,
+    tickLabels = None
   )
 }

--- a/src/main/scala/co/theasi/plotly/Colorscale.scala
+++ b/src/main/scala/co/theasi/plotly/Colorscale.scala
@@ -1,0 +1,6 @@
+package co.theasi.plotly
+
+sealed trait Colorscale
+
+/** Colorscale predefined by Plotly */
+case class ColorscalePredef(s: String) extends Colorscale

--- a/src/main/scala/co/theasi/plotly/Plot.scala
+++ b/src/main/scala/co/theasi/plotly/Plot.scala
@@ -102,7 +102,7 @@ extends Plot {
   type OptionType = CartesianPlotOptions
 
   /** Add a scatter plot to this plot.
-    * 
+    *
     * @usecase def withScatter[X, Y](xs: Iterable[X], ys: Iterable[Y], options: ScatterOptions): CartesianPlot
     *   @inheritdoc
     *
@@ -213,6 +213,38 @@ object CartesianPlot {
   * draw(figure, "3d-subplots")
   * }}}
   *
+  * ==Surface plots==
+  *
+  * Add a surface plot with the `withSurface` method:
+  * {{{
+  * val xs = Vector(-1.0, 0.0, 1.0)
+  * val ys = Vector(0.0, 10.0)
+  *
+  * val zs = Vector(
+  *   Vector(1.0, 2.0, 1.0),
+  *   Vector(5,0, 4.0, 5.0)
+  * )
+  *
+  * val p = ThreeDPlot().withSurface(xs, ys, zs)
+  * }}}
+  *
+  * The ''z''-values are assumed to be nested iterables, oriented such that
+  * `zs(0)(1)` is the value of ''z'' at `xs(1)` and `ys(0)`.
+  *
+  * You can also pass in options to control how the surface is represented:
+  *
+  * {{{
+  * val p = ThreeDPlot().withSurface(xs, ys, zs, SurfaceOptions().opacity(0.4))
+  * }}}
+  *
+  * See the documentation for [[SurfaceOptions]] for a list of available
+  * options.
+  *
+  * `.withSurface` also supports passing a `zs` iterable
+  *  without `xs` and `ys`.
+  *  This is equivalent to having `xs = (0 to zs(0).size)` and
+  * `ys = (0 to zs.size)`.
+  *
   * ==Multiple surfaces==
   *
   * `ThreeDPlot` instances support multiple surfaces:
@@ -229,6 +261,7 @@ object CartesianPlot {
   *   .withSurface(zs1, SurfaceOptions().name("top"))
   *   .withSurface(zs2, SurfaceOptions().name("bottom"))
   * }}}
+  *
   *
   * ==The immutable builder pattern==
   *
@@ -264,7 +297,22 @@ object CartesianPlot {
   *   .yAxisOptions(AxisOptions().title("y-axis").titleColor(255, 0, 0))
   *   .zAxisOptions(AxisOptions().title("z-axis").noGrid)
   * }}}
-  * 
+  *
+  *
+  * @define zsurfacedefnoxy The values of z. This is an iterable of iterables of
+  * any type `T`, provided an instance of the typeclass `Writable[T]` exists.
+  * The values of `zs` are oriented such that `zs(0)(1)` corresponds to
+  * the value of ''z'' at ''x = 1'' and ''y = 0''.
+
+  * @define zsurfacedefxy The values of z. This is an iterable of iterables of
+  * any type `T`, provided an instance of the typeclass `Writable[T]` exists.
+  * The values of `zs` are oriented such that `zs(0)(1)` corresponds to
+  * the value of z at `xs(1)` and ``ys(0)``.
+  *
+  * @define optionsurface Options controlling the style in which the
+  *   surface is drawn.
+  *
+  * @define surfaceretval Copy of this plot with the surface added.
   */
 case class ThreeDPlot(
   series: Vector[Series],
@@ -273,31 +321,18 @@ extends Plot {
 
   type OptionType = ThreeDPlotOptions
 
-  /** Add a surface plot to this plot.
+  /** Add a surface plot to this plot with default x and y.
+    *
+    * This adds a surface plot where x and y values are assumed to range from
+    * 0 to `zs(0).size` and 0 to `zs.size` respectively.
     *
     * @usecase def withSurface[Z](zs: Iterable[Iterable[Z]], options: SurfaceOptions): ThreeDPlot
     *   @inheritdoc
     *
-    * @example {{{
-    * val zs = Vector(
-    *   Vector(1.0, 2.0, 1.0),
-    *   Vector(5.0, 4.0, 5.0),
-    *   Vector(3.0, 2.0, 3.0),
-    *   Vector(1.0, 2.0, 1.0)
-    * )
+    * @param zs $zsurfacedefnoxy
+    * @param options $optionsurface
     *
-    * val p = ThreeDPlot()
-    *   .withSurface(zs, SurfaceOptions().name("series-1"))
-    * }}}
-    *
-    * @param zs The values of z. This is an iterable of iterables of any
-    *   type T, provided an instance of the typeclass 'Writable[T]' exists.
-    *   The values of `zs` are oriented such that `zs(0)(1)` corresponds to
-    *   the value of z at x = 0 and y = 1.
-    * @param options (optional) Options controlling the style in which the
-    *   surface is drawn.
-    *
-    * @return Copy of this plot with the surface series added.
+    * @return $surfaceretval
     */
   def withSurface[Z: Writable](
     zs: Iterable[Iterable[Z]],
@@ -309,9 +344,31 @@ extends Plot {
     copy(series = series :+ SurfaceZ(zsAsPType, options))
   }
 
+  /** Add a surface plot to this plot with default x and y.
+    *
+    * This adds a surface plot where x and y values are assumed to range from
+    * 0 to `zs(0).size` and 0 to `zs.size` respectively.
+    *
+    * @usecase def withSurface[Z](zs: Iterable[Iterable[Z]]): ThreeDPlot
+    *   @inheritdoc
+    *
+    * @param zs $zsurfacedefnoxy
+    *
+    * @return $surfaceretval
+    */
   def withSurface[Z: Writable](zs: Iterable[Iterable[Z]]): ThreeDPlot =
     withSurface(zs, SurfaceOptions())
 
+  /** Add a surface plot to this plot.
+    *
+    * @usecase def withSurface[X, Y, Z](xs: Iterable[X], ys: Iterable[Y], zs: Iterable[Iterable[Z]], options: SurfaceOptions): ThreeDPlot
+    *   @inheritdoc
+    *
+    * @param zs $zsurfacedefxy
+    * @param options $optionsurface
+    *
+    * @return $surfaceretval
+    */
   def withSurface[X: Writable, Y: Writable, Z: Writable](
     xs: Iterable[X],
     ys: Iterable[Y],
@@ -326,6 +383,15 @@ extends Plot {
     copy(series = series :+ SurfaceXYZ(xsAsPType, ysAsPType, zsAsPType, options))
   }
 
+  /** Add a surface plot to this plot.
+    *
+    * @usecase def withSurface[X, Y, Z](xs: Iterable[X], ys: Iterable[Y], zs: Iterable[Iterable[Z]]): ThreeDPlot
+    *   @inheritdoc
+    *
+    * @param zs $zsurfacedefxy
+    *
+    * @return $surfaceretval
+    */
   def withSurface[X: Writable, Y: Writable, Z: Writable](
     xs: Iterable[X],
     ys: Iterable[Y],

--- a/src/main/scala/co/theasi/plotly/Plot.scala
+++ b/src/main/scala/co/theasi/plotly/Plot.scala
@@ -301,14 +301,37 @@ extends Plot {
     */
   def withSurface[Z: Writable](
     zs: Iterable[Iterable[Z]],
-    options: SurfaceOptions = SurfaceOptions()
+    options: SurfaceOptions
   ): ThreeDPlot = {
     val zsAsPType = zs.map { zRow =>
       zRow.map { implicitly[Writable[Z]].toPType }
     }
     copy(series = series :+ SurfaceZ(zsAsPType, options))
-
   }
+
+  def withSurface[Z: Writable](zs: Iterable[Iterable[Z]]): ThreeDPlot =
+    withSurface(zs, SurfaceOptions())
+
+  def withSurface[X: Writable, Y: Writable, Z: Writable](
+    xs: Iterable[X],
+    ys: Iterable[Y],
+    zs: Iterable[Iterable[Z]],
+    options: SurfaceOptions
+  ): ThreeDPlot = {
+    val xsAsPType = xs.map { implicitly[Writable[X]].toPType }
+    val ysAsPType = ys.map { implicitly[Writable[Y]].toPType }
+    val zsAsPType = zs.map { zRow =>
+      zRow.map { implicitly[Writable[Z]].toPType }
+    }
+    copy(series = series :+ SurfaceXYZ(xsAsPType, ysAsPType, zsAsPType, options))
+  }
+
+  def withSurface[X: Writable, Y: Writable, Z: Writable](
+    xs: Iterable[X],
+    ys: Iterable[Y],
+    zs: Iterable[Iterable[Z]]
+  ): ThreeDPlot =
+    withSurface(xs, ys, zs, SurfaceOptions())
 
   /** Set options for the x-axis
     *

--- a/src/main/scala/co/theasi/plotly/Series.scala
+++ b/src/main/scala/co/theasi/plotly/Series.scala
@@ -99,3 +99,16 @@ case class SurfaceZ[Z <: PType](
   def options(newOptions: SurfaceOptions): SurfaceZ[Z] =
     copy(options = newOptions)
 }
+
+case class SurfaceXYZ[X <: PType, Y <: PType, Z <: PType](
+  val xs: Iterable[X],
+  val ys: Iterable[Y],
+  val zs: Iterable[Iterable[Z]],
+  val options: SurfaceOptions
+) extends ThreeDSeries {
+  type Self = SurfaceXYZ[X, Y, Z]
+  type OptionType = SurfaceOptions
+
+  def options(newOptions: SurfaceOptions): SurfaceXYZ[X, Y, Z] =
+    copy(options = newOptions)
+}

--- a/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
@@ -6,9 +6,15 @@ case class SurfaceOptions(
   showScale: Option[Boolean],
   colorscale: Option[Colorscale]
 ) extends SeriesOptions {
+
+  /** Set the name of the series */
   def name(newName: String): SurfaceOptions =
     copy(name = Some(newName))
 
+  /** Set the surface opacity.
+    *
+    * @param newOpacity Opacity value; must be between 0 and 1.
+    */
   def opacity(newOpacity: Double): SurfaceOptions = {
     require(
       newOpacity >= 0.0 && newOpacity <= 1.0,
@@ -16,9 +22,16 @@ case class SurfaceOptions(
     copy(opacity = Some(newOpacity))
   }
 
+  /** Draw a color bar on the side of the plot mapping from color to z-value */
   def withScale(): SurfaceOptions = copy(showScale = Some(true))
+
+  /** Hide color bar on the side of the plot mapping from color to z-value */
   def noScale(): SurfaceOptions = copy(showScale = Some(false))
 
+  /** Set the colorscale.
+    *
+    * @param newColorscale Colorscale name
+    */
   def colorscale(newColorscale: String) =
     copy(colorscale = Some(ColorscalePredef(newColorscale)))
 }

--- a/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
@@ -1,5 +1,13 @@
 package co.theasi.plotly
 
+/** Options controlling how surface plots are drawn.
+  *
+  * {{{
+  * val surfaceOptions = SurfaceOptions().opacity(0.9).colorscale("Electric")
+  *
+  * val plot = ThreeDPlot().withSurface(xs, ys, zs, surfaceOptions)
+  * }}}
+  */
 case class SurfaceOptions(
   name: Option[String],
   opacity: Option[Double],

--- a/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
@@ -2,7 +2,8 @@ package co.theasi.plotly
 
 case class SurfaceOptions(
   name: Option[String],
-  opacity: Option[Double]
+  opacity: Option[Double],
+  showScale: Option[Boolean]
 ) extends SeriesOptions {
   def name(newName: String): SurfaceOptions =
     copy(name = Some(newName))
@@ -14,12 +15,15 @@ case class SurfaceOptions(
     copy(opacity = Some(newOpacity))
   }
 
+  def withScale(): SurfaceOptions = copy(showScale = Some(true))
+  def noScale(): SurfaceOptions = copy(showScale = Some(false))
 }
 
 
 object SurfaceOptions {
   def apply(): SurfaceOptions = SurfaceOptions(
     name = None,
-    opacity = None
+    opacity = None,
+    showScale = None
   )
 }

--- a/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
@@ -3,7 +3,8 @@ package co.theasi.plotly
 case class SurfaceOptions(
   name: Option[String],
   opacity: Option[Double],
-  showScale: Option[Boolean]
+  showScale: Option[Boolean],
+  colorscale: Option[Colorscale]
 ) extends SeriesOptions {
   def name(newName: String): SurfaceOptions =
     copy(name = Some(newName))
@@ -17,6 +18,9 @@ case class SurfaceOptions(
 
   def withScale(): SurfaceOptions = copy(showScale = Some(true))
   def noScale(): SurfaceOptions = copy(showScale = Some(false))
+
+  def colorscale(newColorscale: String) =
+    copy(colorscale = Some(ColorscalePredef(newColorscale)))
 }
 
 
@@ -24,6 +28,8 @@ object SurfaceOptions {
   def apply(): SurfaceOptions = SurfaceOptions(
     name = None,
     opacity = None,
-    showScale = None
+    showScale = None,
+    colorscale = None
   )
 }
+ 

--- a/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
@@ -29,6 +29,8 @@ case class SurfaceOptions(
   def noScale(): SurfaceOptions = copy(showScale = Some(false))
 
   /** Set the colorscale.
+    *  A list of predefined colorscales is available at
+    * [[https://github.com/plotly/plotly.js/blob/master/src/components/colorscale/scales.js]]
     *
     * @param newColorscale Colorscale name
     */

--- a/src/main/scala/co/theasi/plotly/writer/Api.scala
+++ b/src/main/scala/co/theasi/plotly/writer/Api.scala
@@ -55,6 +55,7 @@ object Api {
     val response = request.asString
     if (!response.is2xx) {
       val responseBody = parse(response.body)
+      println(compact(render(responseBody)))
       val JString(msg) = responseBody \ "detail"
       throw new PlotlyException(msg)
     }

--- a/src/main/scala/co/theasi/plotly/writer/Api.scala
+++ b/src/main/scala/co/theasi/plotly/writer/Api.scala
@@ -55,7 +55,6 @@ object Api {
     val response = request.asString
     if (!response.is2xx) {
       val responseBody = parse(response.body)
-      println(compact(render(responseBody)))
       val JString(msg) = responseBody \ "detail"
       throw new PlotlyException(msg)
     }

--- a/src/main/scala/co/theasi/plotly/writer/AxisOptionsWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/AxisOptionsWriter.scala
@@ -18,6 +18,7 @@ object AxisOptionsWriter {
     ("tickfont" -> FontWriter.toJson(options.tickFont)) ~
     ("autotick" -> options.autoTick) ~
     ("dtick" -> options.tickSpacing) ~
-    ("tickcolor" -> options.tickColor.map(ColorWriter.toJson _))
+    ("tickcolor" -> options.tickColor.map(ColorWriter.toJson _)) ~
+    ("showticklabels" -> options.tickLabels)
   )
 }

--- a/src/main/scala/co/theasi/plotly/writer/ColorscaleWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/ColorscaleWriter.scala
@@ -1,0 +1,13 @@
+package co.theasi.plotly.writer
+
+import co.theasi.plotly.{Colorscale, ColorscalePredef}
+
+import org.json4s._
+
+object ColorscaleWriter {
+  def toJson(colorscale: Colorscale): JValue = {
+    colorscale match {
+      case ColorscalePredef(v) => JString(v)
+    }
+  }
+}

--- a/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
@@ -18,7 +18,8 @@ object OptionsWriter {
   def surfaceOptionsToJson(options: SurfaceOptions): JObject = (
     ("name" -> options.name) ~
     ("opacity" -> options.opacity) ~
-    ("showscale" -> options.showScale)
+    ("showscale" -> options.showScale) ~
+    ("colorscale" -> options.colorscale.map { ColorscaleWriter.toJson })
   )
 
   private def scatterModeToJson(mode: Seq[ScatterMode.Value])

--- a/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
@@ -17,7 +17,8 @@ object OptionsWriter {
 
   def surfaceOptionsToJson(options: SurfaceOptions): JObject = (
     ("name" -> options.name) ~
-    ("opacity" -> options.opacity)
+    ("opacity" -> options.opacity) ~
+    ("showscale" -> options.showScale)
   )
 
   private def scatterModeToJson(mode: Seq[ScatterMode.Value])

--- a/src/main/scala/co/theasi/plotly/writer/SeriesWriteInfo.scala
+++ b/src/main/scala/co/theasi/plotly/writer/SeriesWriteInfo.scala
@@ -3,7 +3,7 @@ package co.theasi.plotly.writer
 import co.theasi.plotly.{SeriesOptions, ScatterOptions,
   BarOptions, BoxOptions, SurfaceOptions}
 
-trait SeriesWriteInfo {
+sealed trait SeriesWriteInfo {
   val srcs: List[String]
   val options: SeriesOptions
 }
@@ -26,8 +26,16 @@ case class BoxWriteInfo(
   options: BoxOptions
 ) extends SeriesWriteInfo
 
-case class SurfaceWriteInfo(
+case class SurfaceZWriteInfo(
   srcs: List[String],
   sceneIndex: Int,
   options: SurfaceOptions
 ) extends SeriesWriteInfo
+
+case class SurfaceXYZWriteInfo(
+  srcs: List[String],
+  sceneIndex: Int,
+  options: SurfaceOptions
+) extends SeriesWriteInfo
+
+

--- a/src/main/scala/co/theasi/plotly/writer/SeriesWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/SeriesWriter.scala
@@ -13,7 +13,8 @@ object SeriesWriter {
       case s: ScatterWriteInfo => scatterToJson(s)
       case s: BarWriteInfo => barToJson(s)
       case s: BoxWriteInfo => boxToJson(s)
-      case s: SurfaceWriteInfo => surfaceToJson(s)
+      case s: SurfaceZWriteInfo => surfaceZToJson(s)
+      case s: SurfaceXYZWriteInfo => surfaceXYZToJson(s)
     }
   }
 
@@ -42,9 +43,19 @@ object SeriesWriter {
     ("ysrc" -> xsrc) ~ axisToJson(info.axisIndex) ~ ("type" -> "box")
   }
 
-  private def surfaceToJson(info: SurfaceWriteInfo)
+  private def surfaceZToJson(info: SurfaceZWriteInfo)
   : JValue = {
     val List(zsrc) = info.srcs
+    ("zsrc" -> zsrc) ~
+    ("type" -> "surface") ~
+    sceneToJson(info.sceneIndex) ~
+    OptionsWriter.surfaceOptionsToJson(info.options)
+  }
+
+  private def surfaceXYZToJson(info: SurfaceXYZWriteInfo): JValue = {
+    val List(xsrc, ysrc, zsrc) = info.srcs
+    ("xsrc" -> xsrc) ~
+    ("ysrc" -> ysrc) ~
     ("zsrc" -> zsrc) ~
     ("type" -> "surface") ~
     sceneToJson(info.sceneIndex) ~

--- a/src/main/scala/co/theasi/plotly/writer/SeriesWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/SeriesWriter.scala
@@ -1,10 +1,9 @@
 package co.theasi.plotly.writer
 
 import org.json4s._
-import org.json4s.native.JsonMethods._
 import org.json4s.JsonDSL._
 
-import co.theasi.plotly.{SeriesOptions, ScatterOptions, BarOptions, BoxOptions}
+import co.theasi.plotly.{SeriesOptions, SurfaceOptions}
 
 object SeriesWriter {
   def toJson(seriesWriteInfo: SeriesWriteInfo)
@@ -47,9 +46,7 @@ object SeriesWriter {
   : JValue = {
     val List(zsrc) = info.srcs
     ("zsrc" -> zsrc) ~
-    ("type" -> "surface") ~
-    sceneToJson(info.sceneIndex) ~
-    OptionsWriter.surfaceOptionsToJson(info.options)
+    surfaceToJsonHelper(info.sceneIndex, info.options)
   }
 
   private def surfaceXYZToJson(info: SurfaceXYZWriteInfo): JValue = {
@@ -57,9 +54,13 @@ object SeriesWriter {
     ("xsrc" -> xsrc) ~
     ("ysrc" -> ysrc) ~
     ("zsrc" -> zsrc) ~
+    surfaceToJsonHelper(info.sceneIndex, info.options)
+  }
+
+  private def surfaceToJsonHelper(plotIndex: Int, options: SurfaceOptions) = {
     ("type" -> "surface") ~
-    sceneToJson(info.sceneIndex) ~
-    OptionsWriter.surfaceOptionsToJson(info.options)
+    sceneToJson(plotIndex) ~
+    OptionsWriter.surfaceOptionsToJson(options)
   }
 
   private def axisToJson(axisIndex: Int): JObject =

--- a/src/test/scala/co/theasi/plotly/SurfaceOptionsSpec.scala
+++ b/src/test/scala/co/theasi/plotly/SurfaceOptionsSpec.scala
@@ -9,4 +9,10 @@ class SurfaceOptionsSpec extends FlatSpec with Matchers {
     opts0.opacity shouldEqual(Some(0.4))
   }
 
+  it should "support setting the scale" in {
+    val opts = SurfaceOptions()
+    opts.withScale().showScale shouldEqual Some(true)
+    opts.noScale().showScale shouldEqual Some(false)
+  }
+
 }

--- a/src/test/scala/co/theasi/plotly/SurfaceOptionsSpec.scala
+++ b/src/test/scala/co/theasi/plotly/SurfaceOptionsSpec.scala
@@ -9,10 +9,16 @@ class SurfaceOptionsSpec extends FlatSpec with Matchers {
     opts0.opacity shouldEqual(Some(0.4))
   }
 
-  it should "support setting the scale" in {
+  it should "support setting whether to show the scale" in {
     val opts = SurfaceOptions()
     opts.withScale().showScale shouldEqual Some(true)
     opts.noScale().showScale shouldEqual Some(false)
+  }
+
+  it should "support setting the colorscale to a predefined scale" in {
+    val opts = SurfaceOptions()
+    opts.colorscale("Viridis").colorscale shouldEqual Some(
+      ColorscalePredef("Viridis"))
   }
 
 }

--- a/src/test/scala/co/theasi/plotly/writer/OptionsWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/OptionsWriterSpec.scala
@@ -1,0 +1,23 @@
+package co.theasi.plotly.writer
+
+import org.scalatest._
+
+import org.json4s._
+
+import co.theasi.plotly.SurfaceOptions
+
+class OptionsWriterSpec extends FlatSpec with Matchers {
+
+  "surfaceOptionsToJson" should "serialize the colorscale if present" in {
+    val surfaceOptions = SurfaceOptions().colorscale("Viridis")
+    val jobj = OptionsWriter.surfaceOptionsToJson(surfaceOptions)
+    (jobj \ "colorscale") shouldEqual JString("Viridis")
+  }
+
+  it should "omit the colorscale if absent" in {
+    val surfaceOptions = SurfaceOptions()
+    val jobj = OptionsWriter.surfaceOptionsToJson(surfaceOptions)
+    (jobj \ "colorscale") shouldEqual JNothing
+  }
+
+}

--- a/src/test/scala/co/theasi/plotly/writer/SeriesWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/SeriesWriterSpec.scala
@@ -17,6 +17,21 @@ class SeriesWriterSpec extends FlatSpec with Matchers {
     val jobj = SeriesWriter.toJson(writeInfo)
     (jobj \ "zsrc") shouldEqual JString("src1")
     (jobj \ "scene") shouldEqual JString("scene2")
+    (jobj \ "type") shouldEqual JString("surface")
+  }
+
+  it should "serialize the srcs and scenes for xyz-surfaces" in {
+    val srcs = List("x-src", "y-src", "z-src")
+    val sceneIndex = 3
+    val options = SurfaceOptions()
+    val writeInfo = SurfaceXYZWriteInfo(srcs, sceneIndex, options)
+
+    val jobj = SeriesWriter.toJson(writeInfo)
+    (jobj \ "xsrc") shouldEqual JString("x-src")
+    (jobj \ "ysrc") shouldEqual JString("y-src")
+    (jobj \ "zsrc") shouldEqual JString("z-src")
+    (jobj \ "scene") shouldEqual JString("scene3")
+    (jobj \ "type") shouldEqual JString("surface")
   }
 
 }

--- a/src/test/scala/co/theasi/plotly/writer/SeriesWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/SeriesWriterSpec.scala
@@ -12,7 +12,7 @@ class SeriesWriterSpec extends FlatSpec with Matchers {
     val srcs = List("src1")
     val sceneIndex = 2
     val options = SurfaceOptions()
-    val writeInfo = SurfaceWriteInfo(srcs, sceneIndex, options)
+    val writeInfo = SurfaceZWriteInfo(srcs, sceneIndex, options)
 
     val jobj = SeriesWriter.toJson(writeInfo)
     (jobj \ "zsrc") shouldEqual JString("src1")

--- a/src/test/scala/co/theasi/plotly/writer/WriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/WriterSpec.scala
@@ -19,6 +19,7 @@ class WriterSpec extends FlatSpec with Matchers {
   val testX1 = Vector(1.0, 2.0, 3.0)
   val testX2 = Vector(1, 2, 3)
   val testY1 = Vector(4.0, 5.0, 7.0)
+  val testY2 = Vector(5, 10)
   val testText1 = Vector("A", "B", "C")
   val testZData = Vector(Vector(1.0, 2.0, 3.0), Vector(1.0, 4.0, 3.0))
 
@@ -151,5 +152,14 @@ class WriterSpec extends FlatSpec with Matchers {
     val series0 = (jsonResponse \ "data")(0)
     checkTestZData(series0 \ "z")
     series0 \ "type" shouldEqual JString("surface")
+  }
+
+  it should "draw a 3D plot with x, y and z" in {
+    val p = ThreeDPlot()
+      .withSurface(testX1, testY2, testZData)
+    val plotFile = draw(p, randomFileName)
+    val jsonResponse = getJsonForPlotFile(plotFile)
+    val series0 = (jsonResponse \ "data")(0)
+    checkTestZData(series0 \ "z")
   }
 }


### PR DESCRIPTION
Prior to this PR, the user could only draw surface plots with set x and y values.

This PR adds the `.withSurface(xs, ys, zs, options)` that allows setting x and y values, as well as options. It also adds additional surface options.