### PR TITLE
Remove unused imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ organization := "co.theasi"
 
 scalaVersion := "2.11.8"
 
+scalacOptions += "-Ywarn-unused-import"
+
 crossScalaVersions := Seq("2.11.8", "2.10.6")
 
 libraryDependencies ++= Seq(
@@ -33,7 +35,6 @@ publishTo <<= version { (v: String) =>
 parallelExecution in Test := false
 
 logBuffered in Test := false
-
 
 // Documentation
 enablePlugins(SiteScaladocPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,13 @@ organization := "co.theasi"
 
 scalaVersion := "2.11.8"
 
-scalacOptions += "-Ywarn-unused-import"
+def scalacOptionsForVersion(version: String) =
+  CrossVersion.partialVersion(version) match {
+    case Some((2, minor)) if minor >= 11 => "-Ywarn-unused-import"
+    case _ => ""
+  }
+
+scalacOptions += scalacOptionsForVersion(scalaVersion.value)
 
 crossScalaVersions := Seq("2.11.8", "2.10.6")
 

--- a/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
@@ -4,7 +4,7 @@ import org.json4s._
 import org.json4s.JsonDSL._
 
 import co.theasi.plotly.{ScatterOptions, ScatterMode, MarkerOptions,
-  Color, TextValue, StringText, IterableText, SrcText, SurfaceOptions}
+  TextValue, StringText, IterableText, SrcText, SurfaceOptions}
 
 object OptionsWriter {
 
@@ -49,6 +49,5 @@ object OptionsWriter {
         // text series are replaced by textSrc in PlotWriter
       case None => JObject()
     }
-
 
 }

--- a/src/main/scala/co/theasi/plotly/writer/SeriesWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/SeriesWriter.scala
@@ -3,7 +3,7 @@ package co.theasi.plotly.writer
 import org.json4s._
 import org.json4s.JsonDSL._
 
-import co.theasi.plotly.{SeriesOptions, SurfaceOptions}
+import co.theasi.plotly.SurfaceOptions
 
 object SeriesWriter {
   def toJson(seriesWriteInfo: SeriesWriteInfo)


### PR DESCRIPTION
I appended `-Ywarn-unused-import` to the `scalac` options in `build.sbt` for this, but haven't included that change in this PR as it doesn't play well with the (convenient) wildcard import in `initialCommands`:

```
$ sbt console
[info] Loading project definition from /home/srs/src/github.com/ASIDataScience/scala-plotly-client/project
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[info] Set current project to plotly (in build file:/home/srs/src/github.com/ASIDataScience/scala-plotly-client/)
[info] Starting scala interpreter...
[info]
<console>:12: warning: Unused import
       import co.theasi.plotly._
                               ^
import co.theasi.plotly._
Welcome to Scala 2.11.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_102).
Type in expressions for evaluation. Or try :help.

scala> <console>:10: warning: Unused import
import co.theasi.plotly._
                        ^
scala>
```