### PR TITLE
Fix bug in extracting y-series

### DIFF
--- a/src/main/scala/co/theasi/plotly/Series.scala
+++ b/src/main/scala/co/theasi/plotly/Series.scala
@@ -24,7 +24,7 @@ sealed trait CartesianSeries extends Series {
   def ysAs[T : Readable]: Iterable[T] = {
     this match {
       case s: CartesianSeries2D[_, _] =>
-        s.xs.map { implicitly[Readable[T]].fromPType(_) }
+        s.ys.map { implicitly[Readable[T]].fromPType(_) }
       case _ =>
         throw new IllegalArgumentException(
           "Cannot extract ys from 1D series")


### PR DESCRIPTION
https://github.com/ASIDataScience/scala-plotly-client/commit/0b1c34f61abe56303aa8fa48d15d7021f3629b64 introduced a bug in which the `ysAs` method was actually extracting the x-series, rather than the y-series as the name suggests.