### PR TITLE
Use Scalastyle for linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ jdk:
   - oraclejdk7
   - openjdk7
   - oraclejdk8
+test:
+  - sbt ++$TRAVIS_SCALA_VERSION test
+  - sbt ++$TRAVIS_SCALA_VERSION scalastyle

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0")
+
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,117 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+  <parameters>
+   <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+   <parameter name="tabSize"><![CDATA[4]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+  <parameters>
+   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+  <parameters>
+   <parameter name="maxParameters"><![CDATA[8]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+  <parameters>
+   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+  <parameters>
+   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+  <parameters>
+   <parameter name="maximum"><![CDATA[10]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+  <parameters>
+   <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+   <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLength"><![CDATA[50]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+  <parameters>
+   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+</scalastyle>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -6,25 +6,6 @@
    <parameter name="maxFileLength"><![CDATA[800]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
-  <parameters>
-   <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
-// See the LICENCE.txt file distributed with this work for additional
-// information regarding copyright ownership.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.]]></parameter>
-  </parameters>
- </check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>

--- a/src/main/scala/co/theasi/plotly/Figure.scala
+++ b/src/main/scala/co/theasi/plotly/Figure.scala
@@ -113,12 +113,12 @@ object Figure {
   * Use the companion object's `apply` method to construct
   * a new figure. Set the content of the plot on the figure
   * with the [[plot]] method.
-  * 
+  *
   * '''Note''' that all the methods on this class return a
   * ''copy'' of the current instance. They do not modify the
   *  instance in place. Instances of `SinglePlotFigure`
   *  are immutable.
-  * 
+  *
   */
 case class SinglePlotFigure(plot: Plot, options: FigureOptions)
 extends Figure {
@@ -170,7 +170,7 @@ object SinglePlotFigure {
   * `val figure = GridFigure(2, 3)` will build a new figure with 6 subplots,
   * arranged in a grid with two rows and three columns. You can then use
   * the [[plot]] method to set the content of specific sub-plots.
-  * 
+  *
   * {{{
   * import util.Random
   * val xs = (0 to 100).map { i => Random.nextGaussian }
@@ -324,7 +324,7 @@ object GridFigure {
   * val xs = (0 to 100).map { i => Random.nextGaussian }
   * val ys = (0 to 100).map { i => Random.nextGaussian }
   * val ys2 = (0 to 100).map { i => Random.nextGaussian }
-  * 
+  *
   * val figure = RowFigure(2) // 2 subplots
   *   .plot(0) { CartesianPlot().withScatter(xs, ys) } // left
   *   .plot(1) { CartesianPlot().withScatter(xs, ys2) } // right

--- a/src/main/scala/co/theasi/plotly/Figure.scala
+++ b/src/main/scala/co/theasi/plotly/Figure.scala
@@ -125,8 +125,8 @@ extends Figure {
 
   type Self = SinglePlotFigure
 
-  def plots = Vector(plot)
-  def viewPorts = Vector(ViewPort((0.0, 1.0), (0.0, 1.0)))
+  def plots: Vector[Plot] = Vector(plot)
+  def viewPorts: Vector[ViewPort] = Vector(ViewPort((0.0, 1.0), (0.0, 1.0)))
 
   /** Set the content of the figure.
     *
@@ -338,9 +338,9 @@ extends Figure {
 
   type Self = RowFigure
 
-  def plots = impl.plots
-  def viewPorts = impl.viewPorts
-  def options = impl.options
+  def plots: Vector[Plot] = impl.plots
+  def viewPorts: Vector[ViewPort] = impl.viewPorts
+  def options: FigureOptions = impl.options
 
   /** Set the content of a sub-plot.
     *

--- a/src/main/scala/co/theasi/plotly/Plot.scala
+++ b/src/main/scala/co/theasi/plotly/Plot.scala
@@ -281,7 +281,7 @@ object CartesianPlot {
   *   .withSurface(zs1)
   *   .withSurface(zs2)
   *  }}}
-  * 
+  *
   * All methods in this class work in the same way: they return a new
   * instance of `ThreeDPlot`. This pattern is called the immutable builder
   * pattern: it is a variant of the common

--- a/src/main/scala/co/theasi/plotly/Series.scala
+++ b/src/main/scala/co/theasi/plotly/Series.scala
@@ -32,15 +32,12 @@ sealed trait CartesianSeries extends Series {
   }
 }
 
-sealed abstract class CartesianSeries1D[
-    X <: PType]
+sealed abstract class CartesianSeries1D[X <: PType]
 extends CartesianSeries {
   val xs: Iterable[X]
 }
 
-sealed abstract class CartesianSeries2D[
-    X <: PType,
-    Y <: PType]
+sealed abstract class CartesianSeries2D[X <: PType, Y <: PType]
 extends CartesianSeries {
   val xs: Iterable[X]
   val ys: Iterable[Y]
@@ -58,9 +55,7 @@ extends CartesianSeries1D[X] {
     copy(options = newOptions)
 }
 
-case class Scatter[
-    X <: PType,
-    Y <: PType](
+case class Scatter[X <: PType, Y <: PType](
     val xs: Iterable[X],
     val ys: Iterable[Y],
     override val options: ScatterOptions)

--- a/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
@@ -55,4 +55,3 @@ object SurfaceOptions {
     colorscale = None
   )
 }
- 

--- a/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
+++ b/src/main/scala/co/theasi/plotly/SurfaceOptions.scala
@@ -42,7 +42,7 @@ case class SurfaceOptions(
     *
     * @param newColorscale Colorscale name
     */
-  def colorscale(newColorscale: String) =
+  def colorscale(newColorscale: String): SurfaceOptions =
     copy(colorscale = Some(ColorscalePredef(newColorscale)))
 }
 

--- a/src/main/scala/co/theasi/plotly/Writable.scala
+++ b/src/main/scala/co/theasi/plotly/Writable.scala
@@ -6,12 +6,12 @@ trait Writable[T] {
 
 trait WritableImplicits {
   implicit object WritableDouble extends Writable[Double] {
-    def toPType(x: Double) = PDouble(x)
+    def toPType(x: Double): PDouble = PDouble(x)
   }
   implicit object WritableInt extends Writable[Int] {
-    def toPType(x: Int) = PInt(x)
+    def toPType(x: Int): PInt = PInt(x)
   }
   implicit object WritableString extends Writable[String] {
-    def toPType(x: String) = PString(x)
+    def toPType(x: String): PString = PString(x)
   }
 }

--- a/src/main/scala/co/theasi/plotly/writer/CartesianPlotLayoutWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/CartesianPlotLayoutWriter.scala
@@ -19,7 +19,7 @@ object CartesianPlotLayoutWriter {
 
     xAxis ~ yAxis
   }
-  
+
 
   private def axisToJson(
     axisIndex: Int,

--- a/src/main/scala/co/theasi/plotly/writer/ColumnWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/ColumnWriter.scala
@@ -19,7 +19,7 @@ object ColumnWriter {
     data
   }
 
-  def ptypeToJson[X <: PType](x: X) = x match {
+  def ptypeToJson[X <: PType](x: X): JValue = x match {
     case PInt(i) => JInt(i)
     case PDouble(d) => JDouble(d)
     case PString(s) => JString(s)

--- a/src/main/scala/co/theasi/plotly/writer/FigureWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/FigureWriter.scala
@@ -73,7 +73,7 @@ object FigureWriter {
       case (s, index) => seriesToColumns(s, index)
     }.toMap
     val grid = Grid(columns)
-    GridWriter.draw(grid, fileName+"-grid", fileOptions)
+    GridWriter.draw(grid, fileName + "-grid", fileOptions)
   }
 
   private def seriesToColumns(
@@ -180,7 +180,7 @@ object FigureWriter {
         val yUid = drawnGrid.columnUids(yColumnName)
         val zPrefix = s"z-$index"
         val zColumnNames = s.zs.transpose.zipWithIndex.map {
-          case (row, rowIndex) => zPrefix + s"-${rowIndex+1}"
+          case (row, rowIndex) => zPrefix + s"-${rowIndex + 1}"
         }
         val zUids = zColumnNames.map { colName =>
           drawnGrid.columnUids(colName)

--- a/src/main/scala/co/theasi/plotly/writer/FigureWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/FigureWriter.scala
@@ -76,6 +76,7 @@ object FigureWriter {
     GridWriter.draw(grid, fileName + "-grid", fileOptions)
   }
 
+  // scalastyle:off cyclomatic.complexity
   private def seriesToColumns(
       series: Series,
       index: Int
@@ -109,6 +110,7 @@ object FigureWriter {
 
     dataColumns ++ optionColumns
   }
+  // scalastyle:on cyclomatic.complexity
 
   private def indicesFromPlots(plots: Vector[Plot]): Vector[Int] = {
     // Get the index of each plot in the output document.

--- a/src/main/scala/co/theasi/plotly/writer/FigureWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/FigureWriter.scala
@@ -14,7 +14,7 @@ object FigureWriter {
       figure: Figure,
       fileName: String,
       fileOptions: FileOptions = FileOptions()
-  )(implicit server: Server) = {
+  )(implicit server: Server): PlotFile = {
     if (fileOptions.overwrite) { deleteIfExists(fileName) }
     val drawnGrid = drawGrid(figure, fileName, fileOptions)
     val body = plotAsJson(figure, drawnGrid, fileName)

--- a/src/main/scala/co/theasi/plotly/writer/SeriesWriteInfo.scala
+++ b/src/main/scala/co/theasi/plotly/writer/SeriesWriteInfo.scala
@@ -37,5 +37,3 @@ case class SurfaceXYZWriteInfo(
   sceneIndex: Int,
   options: SurfaceOptions
 ) extends SeriesWriteInfo
-
-

--- a/src/main/scala/co/theasi/plotly/writer/Server.scala
+++ b/src/main/scala/co/theasi/plotly/writer/Server.scala
@@ -8,6 +8,8 @@ case object ServerWithDefaultCredentials extends Server {
 trait Server {
   def credentials: Credentials
   def url: String
+  // scalastyle:off magic.number
   def connTimeoutMs: Int = 2000
   def readTimeoutMs: Int = 10000
+  // scalastyle:on magic.number
 }

--- a/src/test/scala/co/theasi/plotly/CartesianPlotSpec.scala
+++ b/src/test/scala/co/theasi/plotly/CartesianPlotSpec.scala
@@ -3,7 +3,7 @@ package co.theasi.plotly
 import org.scalatest._
 
 class CartesianPlotSpec extends FlatSpec with Matchers {
-  
+
   "A CartesianPlot" should "allow setting x-axis options" in {
     val p = CartesianPlot().xAxisOptions(AxisOptions().title("hello"))
     p.options.xAxis.options.title shouldEqual Some("hello")


### PR DESCRIPTION
After #23 I had a look at Scala linters and came across [Scalastyle](http://www.scalastyle.org/). It doesn't actually check for unused imports, but that's [an open feature request](https://github.com/scalastyle/scalastyle/issues/193). I created a default rules file with `sbt scalastyleGenerateConfig`, and removed the `HeaderMatchesChecker` check as it was pretty noisy. The current output on this branch is:

```
src/main/scala/co/theasi/plotly/Figure.scala:128:6: Public method must have explicit type
src/main/scala/co/theasi/plotly/Figure.scala:129:6: Public method must have explicit type
src/main/scala/co/theasi/plotly/Figure.scala:341:6: Public method must have explicit type
src/main/scala/co/theasi/plotly/Figure.scala:342:6: Public method must have explicit type
src/main/scala/co/theasi/plotly/Figure.scala:343:6: Public method must have explicit type
src/main/scala/co/theasi/plotly/Series.scala:35:39: There should be no space after a left bracket '['
src/main/scala/co/theasi/plotly/Series.scala:41:39: There should be no space after a left bracket '['
src/main/scala/co/theasi/plotly/Series.scala:61:18: There should be no space after a left bracket '['
src/main/scala/co/theasi/plotly/SurfaceOptions.scala:45:6: Public method must have explicit type
src/main/scala/co/theasi/plotly/Writable.scala:9:8: Public method must have explicit type
src/main/scala/co/theasi/plotly/Writable.scala:12:8: Public method must have explicit type
src/main/scala/co/theasi/plotly/Writable.scala:15:8: Public method must have explicit type
src/main/scala/co/theasi/plotly/writer/ColumnWriter.scala:22:6: Public method must have explicit type
src/main/scala/co/theasi/plotly/writer/FigureWriter.scala:76:34: There should be a space after the plus (+) sign
src/main/scala/co/theasi/plotly/writer/FigureWriter.scala:76:34: There should be a space before the plus (+) sign
src/main/scala/co/theasi/plotly/writer/FigureWriter.scala:183:57: There should be a space before the plus (+) sign
src/main/scala/co/theasi/plotly/writer/FigureWriter.scala:79:14: Cyclomatic complexity of 11 exceeds max of 10
src/main/scala/co/theasi/plotly/writer/FigureWriter.scala:13:6: Public method must have explicit type
src/main/scala/co/theasi/plotly/writer/Server.scala:11:27: Magic Number
src/main/scala/co/theasi/plotly/writer/Server.scala:12:27: Magic Number
```

There's also [WartRemover](https://github.com/puffnfresh/wartremover), which appears more focused on identifying code smells than aesthetic issues.
