### PR TITLE
Correct major version reference in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.11.8"
 
 def scalacOptionsForVersion(version: String) =
   CrossVersion.partialVersion(version) match {
-    case Some((2, minor)) if minor >= 11 => "-Ywarn-unused-import"
+    case Some((2, major)) if major >= 11 => "-Ywarn-unused-import"
     case _ => ""
   }
 


### PR DESCRIPTION
This was misleading as Scala doesn't use [semantic versioning](http://semver.org/), although the version is of the same format.