### PR TITLE
Replace use of deprecated operator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,9 +29,9 @@ initialCommands := """
 publishMavenStyle := true
 
 // Publishing
-publishTo <<= version { (v: String) =>
+publishTo := {
   val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT"))
+  if (isSnapshot.value)
     Some("snapshots" at nexus + "content/repositories/snapshots")
   else
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")


### PR DESCRIPTION
With version 0.13.13 released last week, sbt now shows a deprecation warning on use of the `<<=` operator. Therefore, use the `.value` DSL introduced in 0.13. See the [migration](http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html) and [publishing](http://www.scala-sbt.org/0.13/docs/Publishing.html) docs for details.