### PR TITLE
Test with OpenJDK 8 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 scala:
   - 2.10.6
@@ -6,6 +7,7 @@ jdk:
   - oraclejdk7
   - openjdk7
   - oraclejdk8
+  - openjdk8
 test:
   - sbt ++$TRAVIS_SCALA_VERSION test
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle


### PR DESCRIPTION
This requires configuring the build run on an Ubuntu 14.04 VM, as OpenJDK 8 is not available on the default VMs.