### PR TITLE
Allow setting the type of axis

### DIFF
--- a/src/main/scala/co/theasi/plotly/AxisOptions.scala
+++ b/src/main/scala/co/theasi/plotly/AxisOptions.scala
@@ -70,6 +70,23 @@ case class AxisOptions(
   def withTickLabels: AxisOptions = copy(tickLabels = Some(true))
   def noTickLabels: AxisOptions = copy(tickLabels = Some(false))
 
+  /** Set the axis type
+    *
+    * {{{
+    * val options = AxisOptions().axisType(AxisType.Log)
+    * }}}
+    *
+    * Valid values are:
+    *   - AxisType.Linear
+    *   - AxisType.Log
+    *   - AxisType.Date
+    *   - AxisType.Category
+    *
+    * If left unspecified, plotly tries to determine the
+    * correct axis type by inspecting the data.
+    *
+    * @see https://plot.ly/python/reference/#layout-xaxis-type
+    */
   def axisType(typeValue: AxisType.Value): AxisOptions =
     copy(axisType = Some(typeValue))
   def axisType(typeValue: String): AxisOptions = {

--- a/src/main/scala/co/theasi/plotly/AxisOptions.scala
+++ b/src/main/scala/co/theasi/plotly/AxisOptions.scala
@@ -13,6 +13,7 @@ case class AxisOptions(
   autoTick: Option[Boolean],
   tickSpacing: Option[Double],
   tickColor: Option[Color],
+  axisType: Option[AxisType.Value],
   tickLabels: Option[Boolean]
 ) {
   def title(newTitle: String): AxisOptions = copy(title = Some(newTitle))
@@ -68,6 +69,13 @@ case class AxisOptions(
 
   def withTickLabels: AxisOptions = copy(tickLabels = Some(true))
   def noTickLabels: AxisOptions = copy(tickLabels = Some(false))
+
+  def axisType(typeValue: AxisType.Value): AxisOptions =
+    copy(axisType = Some(typeValue))
+  def axisType(typeValue: String): AxisOptions = {
+    val typeValueEnum = AxisType.withName(typeValue)
+    axisType(typeValueEnum)
+  }
 }
 
 object AxisOptions {
@@ -84,6 +92,7 @@ object AxisOptions {
     autoTick = None,
     tickSpacing = None,
     tickColor = None,
+    axisType = None,
     tickLabels = None
   )
 }

--- a/src/main/scala/co/theasi/plotly/AxisType.scala
+++ b/src/main/scala/co/theasi/plotly/AxisType.scala
@@ -1,0 +1,8 @@
+package co.theasi.plotly
+
+object AxisType extends Enumeration {
+  val Linear = Value("linear")
+  val Log = Value("log")
+  val Date = Value("date")
+  val Category = Value("category")
+}

--- a/src/main/scala/co/theasi/plotly/writer/AxisOptionsWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/AxisOptionsWriter.scala
@@ -3,7 +3,7 @@ package co.theasi.plotly.writer
 import org.json4s._
 import org.json4s.JsonDSL._
 
-import co.theasi.plotly.AxisOptions
+import co.theasi.plotly.{AxisOptions, AxisType}
 
 object AxisOptionsWriter {
   def toJson(options: AxisOptions): JObject = (
@@ -18,7 +18,16 @@ object AxisOptionsWriter {
     ("tickfont" -> FontWriter.toJson(options.tickFont)) ~
     ("autotick" -> options.autoTick) ~
     ("dtick" -> options.tickSpacing) ~
+    ("type" -> axisTypeToJson(options.axisType)) ~
+
     ("tickcolor" -> options.tickColor.map(ColorWriter.toJson _)) ~
     ("showticklabels" -> options.tickLabels)
   )
+
+  private def axisTypeToJson(axisTypeMaybe: Option[AxisType.Value]): JValue = {
+    axisTypeMaybe match {
+      case Some(axisType) => JString(axisType.toString)
+      case None => JNothing
+    }
+  }
 }

--- a/src/test/scala/co/theasi/plotly/AxisOptionsSpec.scala
+++ b/src/test/scala/co/theasi/plotly/AxisOptionsSpec.scala
@@ -1,0 +1,10 @@
+package co.theasi.plotly
+
+import org.scalatest._
+
+class AxisOptionsSpec extends FlatSpec with Matchers {
+  "A AxisOptions" should "allow setting the axis type from string" in {
+    val options = AxisOptions().axisType("log")
+    options.axisType shouldEqual Some(AxisType.Log)
+  }
+}

--- a/src/test/scala/co/theasi/plotly/writer/AxisOptionsWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/AxisOptionsWriterSpec.scala
@@ -1,0 +1,15 @@
+package co.theasi.plotly.writer
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import org.json4s.JString
+
+import co.theasi.plotly.{AxisOptions, AxisType}
+
+class AxisOptionsWriterSpec extends FlatSpec with Matchers {
+  "toJson" should "serialize the plot type" in {
+    val options = AxisOptions().axisType(AxisType.Log)
+    val jobj = AxisOptionsWriter.toJson(options)
+    jobj \ "type" shouldEqual JString("log")
+  }
+}

--- a/src/test/scala/co/theasi/plotly/writer/AxisOptionsWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/AxisOptionsWriterSpec.scala
@@ -2,7 +2,7 @@ package co.theasi.plotly.writer
 
 import org.scalatest.{FlatSpec, Matchers}
 
-import org.json4s.JString
+import org.json4s.{JString, JNothing}
 
 import co.theasi.plotly.{AxisOptions, AxisType}
 
@@ -11,5 +11,11 @@ class AxisOptionsWriterSpec extends FlatSpec with Matchers {
     val options = AxisOptions().axisType(AxisType.Log)
     val jobj = AxisOptionsWriter.toJson(options)
     jobj \ "type" shouldEqual JString("log")
+  }
+
+  it should "serialize to null if the plot type is not specified" in {
+    val options = AxisOptions()
+    val jobj = AxisOptionsWriter.toJson(options)
+    jobj \ "type" shouldEqual JNothing
   }
 }


### PR DESCRIPTION
This PR lets the user specify if they want log, date or categorical axes.

```scala
import co.theasi.plotly._

object Main extends App {

  val xs = Vector(0, 1, 2, 3, 4, 5, 6, 7, 8)
  val ys1 = Vector(8, 7, 6, 5, 4, 3, 2, 1, 0)
  val ys2 = Vector(0, 1, 2, 3, 4, 5, 6, 7, 8)

  val p = CartesianPlot()
    .withScatter(xs, ys1)
    .withScatter(xs, ys2)
    .xAxisOptions(AxisOptions().axisType(AxisType.Log))
    .yAxisOptions(AxisOptions().axisType(AxisType.Log))

  val result = draw(p, "log-plot")
  println(result)
}
```

See the [result](https://plot.ly/~pbugnion/622/) here.