### PR TITLE
Ability to customise lines in scatter plots

### DIFF
--- a/src/main/scala/co/theasi/plotly/ScatterOptions.scala
+++ b/src/main/scala/co/theasi/plotly/ScatterOptions.scala
@@ -168,3 +168,41 @@ object MarkerOptions {
     lineColor = None
   )
 }
+
+
+object DashMode extends Enumeration {
+  val Dash = Value("dash")
+  val Dot = Value("dot")
+  val DashDot = Value("dashdot")
+}
+
+
+case class LineOptions(
+  color: Option[Color],
+  width: Option[Int],
+  dashMode: Option[DashMode.Value]
+) {
+
+  def width(newWidth: Int): LineOptions = copy(width = Some(newWidth))
+
+  def color(newColor: Color): LineOptions =
+    copy(color = Some(newColor))
+  def color(r: Int, g: Int, b: Int, a: Double): LineOptions =
+    color(Color.rgba(r, g, b, a))
+  def color(r: Int, g: Int, b: Int): LineOptions =
+    color(r, g, b, 1.0)
+
+  def dashMode(newDashMode: DashMode.Value): LineOptions =
+    copy(dashMode = Some(newDashMode))
+  def dashMode(newDashMode: String): LineOptions =
+    dashMode(DashMode.withName(newDashMode))
+}
+
+
+object LineOptions {
+  def apply(): LineOptions = LineOptions(
+    color = None,
+    width = None,
+    dashMode = None
+  )
+}

--- a/src/main/scala/co/theasi/plotly/ScatterOptions.scala
+++ b/src/main/scala/co/theasi/plotly/ScatterOptions.scala
@@ -114,9 +114,30 @@ case class ScatterOptions(
     marker(newMarker)
   }
 
+  /** Update the [[LineOptions]] for this series.
+    *
+    * @see [[ScatterOptions.updatedLine]] to updated
+    *    an existing set of line options.
+    */
   def line(newLine: LineOptions): ScatterOptions =
     copy(line = newLine)
 
+  /** Update the [[LineOptions]] for this series.
+    *
+    * @param updater Function mapping the existing [[LineOptions]]
+    *   to new [[LineOptions]].
+    *
+    * @example {{{
+    * val xs = (1 to 10)
+    * val ys = (1 to 10)
+    *
+    * val p = CartesianPlot()
+    *   .withScatter(
+    *      xs, ys,
+    *      ScatterOptions().updatedLine(_.width(5).dashMode(DashMode.Dot))
+    *   )
+    * }}}
+    */
   def updatedLine(updater: LineOptions => LineOptions)
   : ScatterOptions = {
     val newLine = updater(line)

--- a/src/main/scala/co/theasi/plotly/ScatterOptions.scala
+++ b/src/main/scala/co/theasi/plotly/ScatterOptions.scala
@@ -5,7 +5,8 @@ case class ScatterOptions(
   name: Option[String],
   mode: Seq[ScatterMode.Value],
   text: Option[TextValue],
-  marker: MarkerOptions
+  marker: MarkerOptions,
+  line: LineOptions
 ) extends SeriesOptions {
 
   /** Set the name of the series */
@@ -113,6 +114,15 @@ case class ScatterOptions(
     marker(newMarker)
   }
 
+  def line(newLine: LineOptions): ScatterOptions =
+    copy(line = newLine)
+
+  def updatedLine(updater: LineOptions => LineOptions)
+  : ScatterOptions = {
+    val newLine = updater(line)
+    line(newLine)
+  }
+
 }
 
 object ScatterOptions {
@@ -120,7 +130,8 @@ object ScatterOptions {
     name = None,
     mode = Seq.empty,
     text = None,
-    marker = MarkerOptions()
+    marker = MarkerOptions(),
+    line = LineOptions()
   )
 }
 

--- a/src/main/scala/co/theasi/plotly/ScatterOptions.scala
+++ b/src/main/scala/co/theasi/plotly/ScatterOptions.scala
@@ -136,6 +136,7 @@ object ScatterOptions {
 }
 
 object ScatterMode extends Enumeration {
+  val Solid = Value("solid")
   val Marker = Value("markers")
   val Line = Value("lines")
   val Text = Value("text")

--- a/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/OptionsWriter.scala
@@ -3,8 +3,11 @@ package co.theasi.plotly.writer
 import org.json4s._
 import org.json4s.JsonDSL._
 
-import co.theasi.plotly.{ScatterOptions, ScatterMode, MarkerOptions,
-  TextValue, StringText, IterableText, SrcText, SurfaceOptions}
+import co.theasi.plotly.{
+  ScatterOptions, ScatterMode, MarkerOptions,
+  TextValue, StringText, IterableText, SrcText, SurfaceOptions,
+  LineOptions
+}
 
 object OptionsWriter {
 
@@ -12,7 +15,8 @@ object OptionsWriter {
     ("name" -> options.name) ~
     ("mode" -> scatterModeToJson(options.mode)) ~
     textToJson(options.text) ~
-    ("marker" -> markerOptionsToJson(options.marker))
+    ("marker" -> markerOptionsToJson(options.marker)) ~
+    ("line" -> lineOptionsToJson(options.line))
   }
 
   def surfaceOptionsToJson(options: SurfaceOptions): JObject = (
@@ -37,6 +41,12 @@ object OptionsWriter {
         ("width" -> options.lineWidth)
       )
     )
+  }
+
+  private def lineOptionsToJson(options: LineOptions): JObject = {
+    ("color" -> options.color.map(ColorWriter.toJson _)) ~
+    ("width" -> options.width) ~
+    ("dash" -> options.dashMode.map { _.toString})
   }
 
   private def textToJson(text: Option[TextValue]): JObject =

--- a/src/test/scala/co/theasi/plotly/ScatterOptionsSpec.scala
+++ b/src/test/scala/co/theasi/plotly/ScatterOptionsSpec.scala
@@ -30,4 +30,14 @@ class ScatterOptionsSpec extends FlatSpec with Matchers {
     opts2.lineColor.get shouldEqual Color.rgb(20, 21, 22)
   }
 
+  "LineOptions" should "support setting color" in {
+    val expectedColor = Color.rgba(1, 2, 3, 0.2)
+    val opts0 = LineOptions().color(expectedColor)
+    opts0.color.get shouldEqual expectedColor
+    val opts1 = LineOptions().color(1, 2, 3, 0.2)
+    opts1.color.get shouldEqual expectedColor
+    val opts2 = LineOptions().color(1, 2, 3)
+    opts2.color.get shouldEqual expectedColor.copy(a = 1.0)
+  }
+
 }

--- a/src/test/scala/co/theasi/plotly/ScatterOptionsSpec.scala
+++ b/src/test/scala/co/theasi/plotly/ScatterOptionsSpec.scala
@@ -12,6 +12,15 @@ class ScatterOptionsSpec extends FlatSpec with Matchers {
     opts1.mode should contain allOf (Marker, Text)
   }
 
+  it should "support setting the line options" in {
+    val expectedOptions = LineOptions().width(6)
+    val opts = ScatterOptions()
+    val opts0 = opts.line(expectedOptions)
+    opts0.line shouldEqual expectedOptions
+    val opts1 = opts.updatedLine(_.width(6))
+    opts1.line shouldEqual expectedOptions
+  }
+
   "MarkerOptions" should "support setting color" in {
     val opts0 = MarkerOptions().color(Color.rgba(1, 2, 3, 0.2))
     opts0.color.get shouldEqual Color.rgba(1, 2, 3, 0.2)

--- a/src/test/scala/co/theasi/plotly/writer/OptionsWriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/OptionsWriterSpec.scala
@@ -4,7 +4,9 @@ import org.scalatest._
 
 import org.json4s._
 
-import co.theasi.plotly.SurfaceOptions
+import co.theasi.plotly.{
+  SurfaceOptions, ScatterOptions, LineOptions, DashMode
+}
 
 class OptionsWriterSpec extends FlatSpec with Matchers {
 
@@ -18,6 +20,18 @@ class OptionsWriterSpec extends FlatSpec with Matchers {
     val surfaceOptions = SurfaceOptions()
     val jobj = OptionsWriter.surfaceOptionsToJson(surfaceOptions)
     (jobj \ "colorscale") shouldEqual JNothing
+  }
+
+  "scatterOptionsToJson" should "serialize line options" in {
+    val lineOptions = LineOptions()
+      .color(1, 2, 3, 0.5)
+      .width(5)
+      .dashMode(DashMode.Dot)
+    val scatterOptions = ScatterOptions().line(lineOptions)
+    val jobj = OptionsWriter.scatterOptionsToJson(scatterOptions)
+    (jobj \ "line" \ "color") shouldEqual JString("rgba(1, 2, 3, 0.5)")
+    (jobj \ "line" \ "width") shouldEqual JInt(5)
+    (jobj \ "line" \ "dash") shouldEqual JString("dot")
   }
 
 }


### PR DESCRIPTION
For instance:

```scala
import co.theasi.plotly._

object Main extends App {

  val xs = Vector(0, 1, 2, 3, 4, 5, 6, 7, 8)
  val ys1 = Vector(8, 7, 6, 5, 4, 3, 2, 1, 0)
  val ys2 = Vector(0, 1, 2, 3, 4, 5, 6, 7, 8)

  val p = CartesianPlot()
    .withScatter(
      xs, ys1,
      ScatterOptions().updatedLine {
        _.width(6).color(255, 255, 0).dashMode(DashMode.Dot)
      }
    )
    .withScatter(xs, ys2)
    .xAxisOptions(AxisOptions().axisType(AxisType.Log))
    .yAxisOptions(AxisOptions().axisType(AxisType.Log))

  val figure = SinglePlotFigure().plot(p).showLegend()

  val result = draw(figure, "log-plot")
  println(result)
}
```

See the result [here](https://plot.ly/~pbugnion/664/)