### PR TITLE
Added support for 3D scatter plots.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /project/project/
 /project/target/
 /target/
+/.idea

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 name := "plotly"
 
-version := "0.2.1-SNAPSHOT"
+version := "0.2.2-SNAPSHOT"
 
 organization := "co.theasi"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.4"
 
 def scalacOptionsForVersion(version: String) =
   CrossVersion.partialVersion(version) match {
@@ -14,11 +14,11 @@ def scalacOptionsForVersion(version: String) =
 
 scalacOptions += scalacOptionsForVersion(scalaVersion.value)
 
-crossScalaVersions := Seq("2.11.8", "2.10.6")
+crossScalaVersions := Seq("2.11.8", "2.12.4")
 
 libraryDependencies ++= Seq(
-  "org.scalaj" %% "scalaj-http" % "2.2.1",
-  "org.json4s" %% "json4s-native" % "3.4.1",
+  "org.scalaj" %% "scalaj-http" % "2.3.0",
+  "org.json4s" %% "json4s-native" % "3.5.3",
   "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 )
 

--- a/src/main/scala/co/theasi/plotly/Plot.scala
+++ b/src/main/scala/co/theasi/plotly/Plot.scala
@@ -400,6 +400,18 @@ extends Plot {
   ): ThreeDPlot =
     withSurface(xs, ys, zs, SurfaceOptions())
 
+  def withScatter3D[X: Writable, Y: Writable, Z: Writable](
+    xs: Iterable[X],
+    ys: Iterable[Y],
+    zs: Iterable[Z],
+    options: ScatterOptions
+  ): ThreeDPlot = {
+    val xsAsPType:Iterable[PType] = xs.map { implicitly[Writable[X]].toPType }
+    val ysAsPType:Iterable[PType] = ys.map { implicitly[Writable[Y]].toPType }
+    val zsAsPType:Iterable[PType] = zs.map { implicitly[Writable[Z]].toPType }
+    copy(series = series :+ Scatter3D(xsAsPType, ysAsPType, zsAsPType, options))
+  }
+
   /** Set options for the x-axis
     *
     * $axisOptionsExample

--- a/src/main/scala/co/theasi/plotly/Plot.scala
+++ b/src/main/scala/co/theasi/plotly/Plot.scala
@@ -263,6 +263,15 @@ object CartesianPlot {
   *   .withSurface(zs2, SurfaceOptions().name("bottom"))
   * }}}
   *
+  * ==3D Scatter plots==
+  *
+  * Create 3D scatter `ThreeDPlot` instances using `withScatter`:
+  * {{{
+  * val xs = Vector(1.0, 2.0)
+  * val ys = Vector(4.0, 5.0)
+  * val zs = Vector(-1.0, -3.0)
+  * val plot = ThreeDPlot().withScatter(xs, ys, zs)
+  * }}}
   *
   * ==The immutable builder pattern==
   *
@@ -400,11 +409,11 @@ extends Plot {
   ): ThreeDPlot =
     withSurface(xs, ys, zs, SurfaceOptions())
 
-  def withScatter3D[X: Writable, Y: Writable, Z: Writable](
+  def withScatter[X: Writable, Y: Writable, Z: Writable](
     xs: Iterable[X],
     ys: Iterable[Y],
     zs: Iterable[Z],
-    options: ScatterOptions
+    options: ScatterOptions = ScatterOptions()
   ): ThreeDPlot = {
     val xsAsPType:Iterable[PType] = xs.map { implicitly[Writable[X]].toPType }
     val ysAsPType:Iterable[PType] = ys.map { implicitly[Writable[Y]].toPType }

--- a/src/main/scala/co/theasi/plotly/Series.scala
+++ b/src/main/scala/co/theasi/plotly/Series.scala
@@ -67,6 +67,19 @@ extends CartesianSeries2D[X, Y] {
     copy(options = newOptions)
 }
 
+case class Scatter3D[X <: PType, Y <: PType, Z <: PType](
+    val xs: Iterable[X],
+    val ys: Iterable[Y],
+    val zs: Iterable[Z],
+    override val options: ScatterOptions)
+extends ThreeDSeries {
+  type Self = Scatter3D[X, Y, Z]
+  type OptionType = ScatterOptions
+
+  override def options(newOptions: ScatterOptions): Scatter3D[X, Y, Z] =
+    copy(options = newOptions)
+}
+
 case class Bar[X <: PType, Y <: PType](
     val xs: Iterable[X],
     val ys: Iterable[Y],

--- a/src/main/scala/co/theasi/plotly/writer/FigureWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/FigureWriter.scala
@@ -101,6 +101,8 @@ object FigureWriter {
           case (row, 0) => s"y-$index" -> row
           case (row, rowIndex) => s"z-$index-$rowIndex" -> row
         }
+      case s: Scatter3D[_, _, _] =>
+        List(s"x-$index" -> s.xs, s"y-$index" -> s.ys, s"z-$index" -> s.zs)
     }
 
     val optionColumns = series match {
@@ -154,6 +156,17 @@ object FigureWriter {
       index: Int
   ): List[String] = {
     val srcs = series match {
+      case s: Scatter3D[_, _, _] =>
+        val xName = s"x-$index"
+        val yName = s"y-$index"
+        val zName = s"z-$index"
+        val xuid = drawnGrid.columnUids(xName)
+        val yuid = drawnGrid.columnUids(yName)
+        val zuid = drawnGrid.columnUids(zName)
+        val xsrc = s"${drawnGrid.fileId}:$xuid"
+        val ysrc = s"${drawnGrid.fileId}:$yuid"
+        val zsrc = s"${drawnGrid.fileId}:$zuid"
+        List(xsrc, ysrc, zsrc)
       case s: CartesianSeries2D[_, _] =>
         val xName = s"x-$index"
         val yName = s"y-$index"
@@ -275,7 +288,9 @@ object FigureWriter {
       // The casts are really ugly. There must be a better way
       writeInfo = series match {
         case s: Scatter[_, _] => ScatterWriteInfo(srcs, plotIndex, s.options)
+        case s: Scatter3D[_, _, _] => Scatter3DWriteInfo(srcs, plotIndex, s.options)
         case s: Bar[_, _] => BarWriteInfo(srcs, plotIndex, s.options)
+        case s: Box[_] => BoxWriteInfo(srcs, plotIndex, s.options)
         case s: SurfaceZ[_] => SurfaceZWriteInfo(srcs, plotIndex, s.options)
         case s: SurfaceXYZ[_, _, _] => SurfaceXYZWriteInfo(srcs, plotIndex, s.options)
       }

--- a/src/main/scala/co/theasi/plotly/writer/SeriesWriteInfo.scala
+++ b/src/main/scala/co/theasi/plotly/writer/SeriesWriteInfo.scala
@@ -14,6 +14,12 @@ case class ScatterWriteInfo(
   options: ScatterOptions
 ) extends SeriesWriteInfo
 
+case class Scatter3DWriteInfo(
+  srcs: List[String],
+  axisIndex: Int,
+  options: ScatterOptions
+) extends SeriesWriteInfo
+
 case class BarWriteInfo(
   srcs: List[String],
   axisIndex: Int,

--- a/src/main/scala/co/theasi/plotly/writer/SeriesWriter.scala
+++ b/src/main/scala/co/theasi/plotly/writer/SeriesWriter.scala
@@ -10,6 +10,7 @@ object SeriesWriter {
   : JValue = {
     seriesWriteInfo match {
       case s: ScatterWriteInfo => scatterToJson(s)
+      case s: Scatter3DWriteInfo => scatter3DToJson(s)
       case s: BarWriteInfo => barToJson(s)
       case s: BoxWriteInfo => boxToJson(s)
       case s: SurfaceZWriteInfo => surfaceZToJson(s)
@@ -24,6 +25,18 @@ object SeriesWriter {
     ("xsrc" -> xsrc) ~
     ("ysrc" -> ysrc) ~
     axisToJson(info.axisIndex) ~
+    OptionsWriter.scatterOptionsToJson(info.options)
+  }
+
+  private def scatter3DToJson(info: Scatter3DWriteInfo)
+  : JValue = {
+    val List(xsrc, ysrc, zsrc) = info.srcs
+
+    ("xsrc" -> xsrc) ~
+    ("ysrc" -> ysrc) ~
+    ("zsrc" -> zsrc) ~
+    axisToJson3D(info.axisIndex) ~
+    ("type" -> "scatter3d") ~
     OptionsWriter.scatterOptionsToJson(info.options)
   }
 
@@ -68,6 +81,12 @@ object SeriesWriter {
     axisIndex match {
       case 1 => ("xaxis" -> "x") ~ ("yaxis" -> "y")
       case i => ("xaxis" -> s"x$i") ~ ("yaxis" -> s"y$i")
+    }
+
+  private def axisToJson3D(axisIndex: Int): JObject =
+    axisIndex match {
+      case 1 => ("xaxis" -> "x") ~ ("yaxis" -> "y") ~ ("zaxis" -> "z")
+      case i => ("xaxis" -> s"x$i") ~ ("yaxis" -> s"y$i") ~ ("zaxis" -> s"z$i")
     }
 
   private def sceneToJson(plotIndex: Int): JObject =

--- a/src/test/scala/co/theasi/plotly/writer/WriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/WriterSpec.scala
@@ -20,6 +20,7 @@ class WriterSpec extends FlatSpec with Matchers {
   val testX2 = Vector(1, 2, 3)
   val testY1 = Vector(4.0, 5.0, 7.0)
   val testY2 = Vector(5, 10)
+  val testZ1 = Vector(3.0, 1.0, 4.0)
   val testText1 = Vector("A", "B", "C")
   val testZData = Vector(Vector(1.0, 2.0, 3.0), Vector(1.0, 4.0, 3.0))
 
@@ -41,6 +42,11 @@ class WriterSpec extends FlatSpec with Matchers {
   def checkTestY1(arr: JValue) = {
     val JArray(response) = arr
     response.toVector shouldEqual testY1.map { JDouble }
+  }
+
+  def checkTestZ1(arr: JValue) = {
+    val JArray(response) = arr
+    response.toVector shouldEqual testZ1.map { JDouble }
   }
 
   def checkTestY2(arr: JValue) = {
@@ -168,5 +174,18 @@ class WriterSpec extends FlatSpec with Matchers {
     checkTestZData(series0 \ "z")
     checkTestX1(series0 \ "x")
     checkTestY2(series0 \ "y")
+  }
+
+
+  it should "draw a 3D scatter plot" in {
+    val p = ThreeDPlot()
+      .withScatter(testX1, testY1, testZ1)
+    val plotFile = draw(p, randomFileName)
+    val jsonResponse = getJsonForPlotFile(plotFile)
+    val series0 = (jsonResponse \ "data")(0)
+    series0 \ "type" shouldEqual JString("scatter3d")
+    checkTestX1(series0 \ "x")
+    checkTestY1(series0 \ "y")
+    checkTestZ1(series0 \ "z")
   }
 }


### PR DESCRIPTION
Hi!
I've came across this [Stackoverflow entry](https://stackoverflow.com/questions/48366536/in-scala-is-it-possible-to-use-plotlys-scatter3d
) and decided to have a closer look on actually implementing 3D scatter plots.
This commit should add basic 3D scatter plot support, but lacks documentation and test cases. If you are interested I can add those also.
Best regards,
Manfred