### PR TITLE
Update Scala and SBT versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ scala:
   - 2.11.12
   - 2.12.4
 jdk:
-  - oraclejdk7
-  - openjdk7
   - oraclejdk8
   - openjdk8
 test:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 dist: trusty
 language: scala
 scala:
-  - 2.10.6
-  - 2.11.8
+  - 2.11.12
+  - 2.12.4
 jdk:
   - oraclejdk7
   - openjdk7

--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,7 @@ organization := "co.theasi"
 
 scalaVersion := "2.12.4"
 
-def scalacOptionsForVersion(version: String) =
-  CrossVersion.partialVersion(version) match {
-    case Some((2, major)) if major >= 11 => "-Ywarn-unused-import"
-    case _ => ""
-  }
-
-scalacOptions += scalacOptionsForVersion(scalaVersion.value)
+scalacOptions += "-Ywarn-unused-import"
 
 crossScalaVersions := Seq("2.11.12", "2.12.4")
 

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,4 @@ logBuffered in Test := false
 // Documentation
 enablePlugins(SiteScaladocPlugin)
 
-ghpages.settings
-
 git.remoteRepo := "git@github.com:ASIDataScience/scala-plotly-client.git"

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "plotly"
 
-version := "0.2.2-SNAPSHOT"
+version := "0.3.0-SNAPSHOT"
 
 organization := "co.theasi"
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ def scalacOptionsForVersion(version: String) =
 
 scalacOptions += scalacOptionsForVersion(scalaVersion.value)
 
-crossScalaVersions := Seq("2.11.8", "2.12.4")
+crossScalaVersions := Seq("2.11.12", "2.12.4")
 
 libraryDependencies ++= Seq(
   "org.scalaj" %% "scalaj-http" % "2.3.0",

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ crossScalaVersions := Seq("2.11.12", "2.12.4")
 libraryDependencies ++= Seq(
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "org.json4s" %% "json4s-native" % "3.5.3",
-  "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 )
 
 initialCommands := """

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.1")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/src/test/scala/co/theasi/plotly/writer/WriterSpec.scala
+++ b/src/test/scala/co/theasi/plotly/writer/WriterSpec.scala
@@ -14,7 +14,7 @@ class WriterSpec extends FlatSpec with Matchers {
   implicit val testServer = new Server {
     override val credentials = Credentials("PlotlyImageTest", "786r5mecv0")
     override val url = "https://api.plot.ly/v2/"
-    override val readTimeoutMs = 20000
+    override val readTimeoutMs = 60000
   }
   val testX1 = Vector(1.0, 2.0, 3.0)
   val testX2 = Vector(1, 2, 3)


### PR DESCRIPTION
This PR drops support for Scala 2.10 and adds support for Scala 2.12. It also drops tests with Java 7 (though the compiled artefacts may still be compatible).