### PR TITLE
Remove Travis configuration that matches default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+---
 language: scala
 scala:
   - 2.11.12


### PR DESCRIPTION
Trusty based container builds are the default as of August 2017 ([docs](https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System)). Additionally, start the `.travis.yml` with `---\n` as suggested by yamllint.